### PR TITLE
Feature/m83

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
     - @kdxu
 - [UPDATE] 利用していない `mergedMediaConstraints` 関数を削除する
     - @kdxu
+- [CHANGE] WebRTC M83 に対応する
+    - @enm10k
 
 ## 2020.3.1
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ React Native WebRTC Kit に対する有償のサポートについては現在�
 
 ## WebRTC ライブラリについて
 
-本ライブラリは WebRTC M79 に対応しています。
+本ライブラリは WebRTC M83 に対応しています。
 
 本ライブラリが利用する WebRTC ライブラリは、デフォルトの設定では弊社がビルドしたバイナリを指定しています。
 このバイナリは弊社製品用の設定でビルドしてあるので、他のバイナリを使いたい場合は次の方法で入れ替えてください。
@@ -73,7 +73,7 @@ React Native WebRTC Kit に対する有償のサポートについては現在�
 ```
  dependencies {
      implementation 'com.facebook.react:react-native:+'
-     // api "com.github.shiguredo:shiguredo-webrtc-android:79.5.0"
+     // api "com.github.shiguredo:shiguredo-webrtc-android:83.4103.12.2"
      implementation "androidx.annotation:annotation:1.1.0"
      api fileTree(dir: 'libs')
  }

--- a/ReactNativeWebRTCKit.podspec
+++ b/ReactNativeWebRTCKit.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   
   s.dependency "React"
-  s.dependency "WebRTC", "~> 79.5.0" # source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
+  s.dependency "WebRTC", "~> 83.4103.12.0" # source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "com.github.shiguredo:shiguredo-webrtc-android:79.5.1"
+    api "com.github.shiguredo:shiguredo-webrtc-android:83.4103.12.2"
     implementation "androidx.annotation:annotation:1.1.0"
 }
   

--- a/ios/WebRTCModule+RTCPeerConnection.m
+++ b/ios/WebRTCModule+RTCPeerConnection.m
@@ -209,6 +209,8 @@ static const char *streamIdsKey = "streamIds";
             return @"recvonly";
         case RTCRtpTransceiverDirectionInactive:
             return @"inactive";
+        case RTCRtpTransceiverDirectionStopped:
+            return @"stopped";
     }
 }
 


### PR DESCRIPTION
## 変更内容

- WebRTC M83 に対応しました

## メモ

- iOS 側で発生したビルド・エラーを修正するために、 ios/WebRTCModule+RTCPeerConnection.m を修正しています
  - libwebrtc の更新で RTCRtpTransceiverDirection という enum に新しい値 (=RTCRtpTransceiverDirectionStopped ) が追加されており、 switch の case が不足したためエラーになっていました
- 追加された値 RTCRtpTransceiverDirectionStopped は、 transceiver のリソースを開放する処理を実装していく目的で導入されたようです
  - 参照: https://bugs.chromium.org/p/chromium/issues/detail?id=980879

> Without being able to stop a transceiver, it is impossible to free up expensive resources, because even inactive transceiver, unless stopped, can become active again. Even with browser optimizations to free encoders and decoders(?), we cannot free the receiver's MediaStreamTrack image buffer because we cannot end the track.
> ...