### PR TITLE
unused import や flow の宣言、コメントのスペースを整理する

### DIFF
--- a/src/Event/RTCEvents.js
+++ b/src/Event/RTCEvents.js
@@ -1,6 +1,5 @@
 // @flow
 
-import RTCMediaStream from '../MediaStream/RTCMediaStream';
 import RTCMediaStreamTrack from '../MediaStream/RTCMediaStreamTrack';
 import RTCIceCandidate from '../PeerConnection/RTCIceCandidate';
 import RTCRtpReceiver from '../PeerConnection/RTCRtpReceiver';
@@ -48,14 +47,14 @@ export class RTCMediaStreamTrackEvent {
 
     /**
      * レシーバー
-     * 
+     *
      * @since 1.1.0
      */
     receiver: RTCRtpReceiver | null;
 
     /**
      * トランシーバー
-     * 
+     *
      * @since 1.1.0
      */
     transceiver: RTCRtpTransceiver | null;

--- a/src/MediaDevice/RTCAudioPort.js
+++ b/src/MediaDevice/RTCAudioPort.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { NativeModules, Platform } from 'react-native';
 import logger from '../Util/RTCLogger';
 
@@ -10,7 +12,7 @@ const { WebRTCModule } = NativeModules;
  * - `'speaker'` - スピーカー
  * - `'unknown'` - 不明
  * @typedef {string} RTCAudioPort
- * 
+ *
  * @since 2.1.0
  */
 export type RTCAudioPort =
@@ -30,9 +32,9 @@ function nativeSetAudioPort(port: RTCAudioPort): Promise<void> {
 
 /**
  * 音声の出力元を取得します。(iOS のみ)
- * 
+ *
  * @return {Promise<RTCAudioPort>}
- * 
+ *
  * @since 2.1.0
  */
 export function getAudioPort(): Promise<RTCAudioPort> {
@@ -47,10 +49,10 @@ export function getAudioPort(): Promise<RTCAudioPort> {
 
 /**
  * 音声の出力先を指定します。(iOS のみ)
- * 
+ *
  * @param {RTCAudioPort} port 音声の出力先
  * @returns {void}
- * 
+ *
  * @since 2.1.0
  */
 export function setAudioPort(port: RTCAudioPort): Promise<void> {

--- a/src/MediaDevice/getUserMedia.js
+++ b/src/MediaDevice/getUserMedia.js
@@ -1,8 +1,6 @@
 // @flow
 
 import { NativeModules } from 'react-native';
-import WebRTC from '../WebRTC';
-import RTCMediaStream from '../MediaStream/RTCMediaStream';
 import RTCMediaStreamTrack from '../MediaStream/RTCMediaStreamTrack';
 import RTCMediaStreamConstraints from '../MediaStream/RTCMediaStreamConstraints';
 import RTCMediaStreamError from '../MediaStream/RTCMediaStreamError';
@@ -13,7 +11,7 @@ const { WebRTCModule } = NativeModules;
 
 /**
  * {@link getUserMedia} で取得できるメディア情報入力トラックの情報です。
- * 
+ *
  * @since 1.1.0
  */
 export class RTCUserMedia {
@@ -46,16 +44,16 @@ export class RTCUserMedia {
 
 }
 
-/** 
+/**
  * カメラやマイクなどのメディア情報入力デバイスのトラックを生成します。
  * この関数を実行するとデバイスの使用許可がユーザーに要求され、
  * ユーザーが許可すると、 Promise は {@link RTCUserMedia} を引数として解決されます。
  * {@link RTCPeerConnection} でトラックを利用するには `addTrack()` で追加します。
- * 
+ *
  * この関数で生成されるトラックの使用は一度きりです。
  * 再び入力デバイスを使う場合は、再度この関数を実行して
  * 新しいトラックを生成する必要があります。
- * 
+ *
  * @example
  * getUserMedia(null).then((info) => {
  *   var pc = new RTCPeerConnection();
@@ -64,7 +62,7 @@ export class RTCUserMedia {
  *   );
  *   ...
  * });
- * 
+ *
  * @param {RTCMediaStreamConstraints|null} constraints トラックの制約
  * @returns {Promise<RTCUserMedia>} トラックの取得の結果を表す Promise 。
  *  エラー時は {@link RTCMediaStreamError} が渡されます。
@@ -103,7 +101,7 @@ export function getUserMedia(constraints: RTCMediaStreamConstraints | null):
  * 稼働中のすべてのメディア入力デバイスを停止します。
  * デバイスの停止中はストリームにメディアデータが送信されません。
  * 再開するには {@link getUserMedia} を実行します。
- * 
+ *
  * @returns {void}
  */
 export function stopUserMedia(): void {

--- a/src/MediaStream/RTCMediaStream.js
+++ b/src/MediaStream/RTCMediaStream.js
@@ -1,15 +1,11 @@
 // @flow
 
-import { NativeModules } from 'react-native';
-import EventTarget from 'event-target-shim';
-
 import RTCMediaStreamEventTarget from './RTCMediaStreamEventTarget';
 import RTCMediaStreamTrack from './RTCMediaStreamTrack';
-import type { ValueTag } from '../PeerConnection/RTCPeerConnection';
 
 /**
  * @deprecated ストリームの操作は廃止されました。
- * 
+ *
  * @version 1.1.0
  */
 export default class RTCMediaStream extends RTCMediaStreamEventTarget {

--- a/src/PeerConnection/RTCIceCandidate.js
+++ b/src/PeerConnection/RTCIceCandidate.js
@@ -1,7 +1,5 @@
 // @flow
 
-import { NativeModules } from 'react-native';
-
 /**
  * ICE candidate を表すオブジェクトです。
  */

--- a/src/PeerConnection/RTCPeerConnection.js
+++ b/src/PeerConnection/RTCPeerConnection.js
@@ -385,7 +385,6 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
    * @since 1.1.0
    */
   addTrack(track: RTCMediaStreamTrack, streamIds: Array<String>): Promise<RTCRtpSender> {
-    var streamValueTags = [];
     return RTCPeerConnection.nativeAddTrack(this._valueTag, track._valueTag, streamIds)
       .then((info) => {
         logger.log(`# PeerConnection[${this._valueTag}]: addTrack finished: sender => `, info);

--- a/src/PeerConnection/RTCPeerConnection.js
+++ b/src/PeerConnection/RTCPeerConnection.js
@@ -3,7 +3,6 @@
 import { DeviceEventEmitter } from 'react-native';
 import { NativeModules } from 'react-native';
 
-import * as RTCUtil from '../Util/RTCUtil';
 import RTCMediaStream from '../MediaStream/RTCMediaStream';
 import RTCMediaStreamTrack from '../MediaStream/RTCMediaStreamTrack';
 import { RTCEvent, RTCMediaStreamTrackEvent, RTCIceCandidateEvent, RTCDataChannelEvent } from '../Event/RTCEvents';
@@ -18,34 +17,33 @@ import logger from '../Util/RTCLogger';
 import RTCMediaConstraints from './RTCMediaConstraints';
 import RTCDataChannel from './RTCDataChannel';
 import type { RTCDataChannelInit } from './RTCDataChannel';
-import WebRTC from '../WebRTC';
 
 /** @private */
 const { WebRTCModule } = NativeModules;
 
 /**
  * @package
- * 
+ *
  * ネイティブレイヤーのオブジェクトに関連付けられたユニークな文字列です。
  * JavaScript からネイティブのオブジェクトを操作するために使われます。
  * 例えばタグが `foo` であれば、
  * ネイティブレイヤーのオブジェクトのうち、タグが `foo` である
  * オブジェクトを指定して操作できます。
- * 
+ *
  * @typedef {string} ValueTag
  */
 export type ValueTag = string;
 
 /**
  * RTCPeerConnection の接続状態です。
- * 
+ *
  * - `'new'`
  * - `'connecting'`
  * - `'connected'`
  * - `'disconnected'`
  * - `'failed'`
  * - `'closed'`
- * 
+ *
  * @typedef {string} RTCPeerConnectionState
  */
 export type RTCPeerConnectionState =
@@ -58,13 +56,13 @@ export type RTCPeerConnectionState =
 
 /**
  * RTCPeerConnection のシグナリング接続の状態です。
- * 
+ *
  * - `'stable'`
  * - `'have-local-offer'`
  * - `'have-remote-offer'`
  * - `'have-local-pranswer'`
  * - `'have-remote-pranswer'`
- * 
+ *
  * @typedef {string} RTCSignalingState
  */
 export type RTCSignalingState =
@@ -76,11 +74,11 @@ export type RTCSignalingState =
 
 /**
  * RTCPeerConnection の ICE ギャザリングの状態です。
- * 
+ *
  * - `'new'`
  * - `'gathering'`
  * - `'complete'`
- * 
+ *
  * @typedef {string} RTCIceGatheringState
  */
 export type RTCIceGatheringState =
@@ -90,7 +88,7 @@ export type RTCIceGatheringState =
 
 /**
  * RTCPeerConnection の ICE 接続の状態です。
- * 
+ *
  * - `'new'`
  * - `'checking'`
  * - `'connected'`
@@ -98,7 +96,7 @@ export type RTCIceGatheringState =
  * - `'failed'`
  * - `'disconnected'`
  * - `'closed'`
- * 
+ *
  * @typedef {string} RTCIceConnectionState
  */
 export type RTCIceConnectionState =
@@ -224,7 +222,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
   /**
    * センダーのリスト。
    * リストの並びは順不同です。
-   * 
+   *
    * @since 1.1.0
    */
   senders: Array<RTCRtpSender> = [];
@@ -232,7 +230,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
   /**
    * レシーバーのリスト。
    * リストの並びは順不同です。
-   * 
+   *
    * @since 1.1.0
    */
   receivers: Array<RTCRtpReceiver> = [];
@@ -240,7 +238,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
   /**
    * トランシーバーのリスト。
    * リストの並びは順不同です。
-   * 
+   *
    * @since 1.1.0
    */
   transceivers: Array<RTCRtpTransceiver> = [];
@@ -251,10 +249,10 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * オブジェクトを生成し、リモートのピアまたはサーバーに接続します。
-   * 
+   *
    * @param {RTCConfiguration|null} [configuration=null] 設定
    * @param {RTCMediaConstraints|null} [constraints=null] メディアに関する制約
-  * 
+  *
    * @listens {connectionstatechange} `RTCEvent`: `connectionState` が変更されると送信されます。
    * @listens {icecandidate} `RTCIceCandidateEvent`: ICE Candidate が生成されると送信されます。
    * @listens {iceconnectionstatechange} `RTCEvent`: `iceConnectionState` が変更されると送信されます。
@@ -300,7 +298,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * Answer SDP を生成します。
-   * 
+   *
    * @param {RTCMediaConstraints} constraints 制約
    * @return {Promise<RTCSessionDescription>} 生成結果を示す Promise
    */
@@ -312,7 +310,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * Offer SDP を生成します。
-   * 
+   *
    * @param {RTCMediaConstraints} constraints 制約
    * @return {Promise<RTCSessionDescription>} 生成結果を示す Promise
    */
@@ -324,7 +322,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * ICE candidate を追加します。
-   * 
+   *
    * @param {RTCIceCandidate} candidate ICE candidate
    * @return {Promise<Void>} 結果を示す Promise
    */
@@ -334,7 +332,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * @deprecated ストリームの操作は廃止されました。 senders を使用してください。
-   * 
+   *
    * @version 1.1.0
    */
   getLocalStreams(): Array<RTCMediaStream> {
@@ -343,7 +341,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * @deprecated ストリームの操作は廃止されました。 receivers を使用してください。
-   * 
+   *
    * @version 1.1.0
    */
   getRemoteStreams(): Array<RTCMediaStream> {
@@ -352,7 +350,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * @deprecated ストリームの操作は廃止されました。 addTrack() を使用してください。
-   * 
+   *
    * @version 1.1.0
    */
   addStream(stream: RTCMediaStream): void {
@@ -361,7 +359,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * @deprecated ストリームの操作は廃止されました。 addTrack() を使用してください。
-   * 
+   *
    * @version 1.1.0
    */
   addLocalStream(stream: RTCMediaStream): void {
@@ -370,7 +368,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * @deprecated ストリームの操作は廃止されました。 removeTrack() を使用してください。
-   * 
+   *
    * @version 1.1.0
    */
   removeLocalStream(stream: RTCMediaStream): void {
@@ -379,11 +377,11 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * 指定したストリームにトラックを追加します。
-   * 
+   *
    * @param {RTCMediaStreamTrack} track 追加するトラック
    * @param {Array<String>} streamIds トラックを追加するストリーム ID
    * @return {Promise<RTCRtpSender>} 結果を表す Promise 。追加されたトラックを返す
-   * 
+   *
    * @since 1.1.0
    */
   addTrack(track: RTCMediaStreamTrack, streamIds: Array<String>): Promise<RTCRtpSender> {
@@ -399,9 +397,9 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * 送信用のトラックを取り除きます。
-   * 
+   *
    * @param {RTCRtpSender} sender 取り除くトラック
-   * 
+   *
    * @since 1.1.0
    */
   removeTrack(sender: RTCRtpSender): Promise<void> {
@@ -412,7 +410,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * 設定を反映します。
-   * 
+   *
    * @param {RTCConfiguration} configuration 設定
    */
   setConfiguration(configuration: RTCConfiguration): void {
@@ -422,7 +420,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * ローカルの SDP を設定します。
-   * 
+   *
    * @param {RTCSessionDescription} sessionDescription 設定する SDP
    * @return {Promise<void>} セットした結果を示す Promise
    */
@@ -437,7 +435,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
 
   /**
    * リモートの SDP を設定します。
-   * 
+   *
    * @param {RTCSessionDescription} sessionDescription 設定する SDP
    * @return {Promise<void>} セットした結果を示す Promise
    */
@@ -457,7 +455,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
   *  @param {string} label DataChannel の label
   *  @param {RTCDataChannelInit|null} options DataChannel で指定するオプション
   *  @return {Promise<RTCDataChannel>} 結果を表す Promise。作成した DataChannel を返す
-  * 
+  *
   *  @since 2020.3.0
   */
   createDataChannel(label: string, options: RTCDataChannelInit | null = null): Promise<RTCDataChannel> {

--- a/src/VideoView/RTCVideoView.js
+++ b/src/VideoView/RTCVideoView.js
@@ -1,7 +1,6 @@
 // @flow
 
 import {
-  NativeModules,
   requireNativeComponent,
   ViewPropTypes
 } from 'react-native';
@@ -11,17 +10,17 @@ import RTCMediaStreamTrack from '../MediaStream/RTCMediaStreamTrack';
 
 import type { ValueTag } from '../PeerConnection/RTCPeerConnection';
 
-/** 
+/**
  * 映像のサイズ調整方法です。
  * CSS の `object-fit` に近い動作の設定です。
- * 
+ *
  * - `'fill'` -
  *   アスペクト比を無視してビュー全体を埋めます。
- *   
+ *
  * - `'contain'` -
  *   アスペクト比を維持しつつ、ビュー全体の中に映像が収まるようにします。
  *   映像とビューのサイズが異なる場合は、映像の両側に空白が入ります。
- * 
+ *
  * - `'cover'` -
  *   アスペクト比を維持しつつ、ビュー全体を埋めます。
  *
@@ -59,7 +58,7 @@ export default WebRTCVideoView;
 
 /**
  * ストリームから出力される映像を描画します (音声も同時に再生されます) 。
- * 
+ *
  * NOTE: このクラス定義は ESDoc で RTCVideoView の説明を記述するために用意してあります。
  * RTCVideoView は React ネイティブコンポーネントとして実装されており、
  * このクラスのインスタンスは本ライブラリ中では使われません。
@@ -73,14 +72,14 @@ export class RTCVideoView extends React.Component<Props> {
 
   /**
    * @deprecated track を使用してください。
-   * 
+   *
    * @version 1.1.0
    */
   streamValueTag: ValueTag;
 
   /**
    * 描画する映像トラック
-   * 
+   *
    * @since 1.1.0
    */
   track: RTCMediaStreamTrack | null;


### PR DESCRIPTION
- unused import & vars の整理
-  // @flow の宣言忘れを修正
- コメントのスペースを整理する