### PR TITLE
コンストラクタで String と annotation しているものを string に統一する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
 - FIX
     - バグ修正
 
+## develop
+
+- [UPDATE] コンストラクタで String と annotation しているものを string に統一する
+    - @kdxu
+
 ## 2020.4.0
 
 - [UPDATE] unused import や flow の宣言、コメントのスペースを整理する

--- a/src/MediaDevice/getUserMedia.js
+++ b/src/MediaDevice/getUserMedia.js
@@ -32,12 +32,12 @@ export class RTCUserMedia {
   tracks: Array<RTCMediaStreamTrack>;
 
   /** トラックが属するストリーム ID */
-  streamId: String;
+  streamId: string;
 
   /**
    * @ignore
    */
-  constructor(tracks: Array<RTCMediaStreamTrack>, streamId: String) {
+  constructor(tracks: Array<RTCMediaStreamTrack>, streamId: string) {
     this.tracks = tracks;
     this.streamId = streamId;
   }

--- a/src/PeerConnection/RTCPeerConnection.js
+++ b/src/PeerConnection/RTCPeerConnection.js
@@ -135,7 +135,7 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
   /** @private */
   static nativeAddTrack(valueTag: ValueTag,
     trackValueTag: ValueTag,
-    streamIds: Array<String>,
+    streamIds: Array<string>,
   ): Promise<Object> {
     return WebRTCModule.peerConnectionAddTrack(trackValueTag, streamIds, valueTag);
   }
@@ -379,12 +379,12 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
    * 指定したストリームにトラックを追加します。
    *
    * @param {RTCMediaStreamTrack} track 追加するトラック
-   * @param {Array<String>} streamIds トラックを追加するストリーム ID
+   * @param {Array<string>} streamIds トラックを追加するストリーム ID
    * @return {Promise<RTCRtpSender>} 結果を表す Promise 。追加されたトラックを返す
    *
    * @since 1.1.0
    */
-  addTrack(track: RTCMediaStreamTrack, streamIds: Array<String>): Promise<RTCRtpSender> {
+  addTrack(track: RTCMediaStreamTrack, streamIds: Array<string>): Promise<RTCRtpSender> {
     return RTCPeerConnection.nativeAddTrack(this._valueTag, track._valueTag, streamIds)
       .then((info) => {
         logger.log(`# PeerConnection[${this._valueTag}]: addTrack finished: sender => `, info);

--- a/src/PeerConnection/RTCRtpParameters.js
+++ b/src/PeerConnection/RTCRtpParameters.js
@@ -16,7 +16,7 @@ export class RTCRtcpParameters {
   /**
    * CNAME (Canonical Name)
    */
-  cname: String;
+  cname: string;
 
   /**
    * サイズが減らされていれば `true`
@@ -46,7 +46,7 @@ export class RTCRtpHeaderExtensionParameters {
   /**
    * URI
    */
-  uri: String;
+  uri: string;
 
   /**
    * 拡張ヘッダーの ID
@@ -200,12 +200,12 @@ export class RTCRtpCodecParameters {
   /**
    * MIME タイプ
    */
-  mimeType: String;
+  mimeType: string;
 
   /**
    * クロックレート
    */
-  clockRate: String | null;
+  clockRate: string | null;
 
   /**
    * チャンネル数 (モノラルなら 1 、ステレオなら 2)
@@ -215,7 +215,7 @@ export class RTCRtpCodecParameters {
   /**
    * SDP の "a=fmtp" 行に含まれる "format specific parameters"
    */
-  parameters: Map<String, String> = new Map();
+  parameters: Map<string, string> = new Map();
 
   _owner: ValueTag;
 
@@ -243,7 +243,7 @@ export class RTCRtpParameters {
   /**
    * トランザクション ID
    */
-  transactionId: String;
+  transactionId: string;
 
   /**
    * RTCP 用のパラメーター

--- a/src/PeerConnection/RTCRtpReceiver.js
+++ b/src/PeerConnection/RTCRtpReceiver.js
@@ -14,7 +14,7 @@ export default class RTCRtpReceiver {
   /**
    * レシーバー ID
    */
-  receiverId: String;
+  receiverId: string;
 
   /**
    * パラメーター
@@ -31,7 +31,7 @@ export default class RTCRtpReceiver {
    * 
    * @since 2.0.0
    */
-  streamIds: Array<String>;
+  streamIds: Array<string>;
 
   _valueTag: ValueTag;
 

--- a/src/PeerConnection/RTCRtpSender.js
+++ b/src/PeerConnection/RTCRtpSender.js
@@ -14,7 +14,7 @@ export default class RTCRtpSender {
   /**
    * センダー ID
    */
-  id: String;
+  id: string;
 
   /**
    * パラメーター
@@ -31,7 +31,7 @@ export default class RTCRtpSender {
    * 
    * @since 2.0.0
    */
-  streamIds: Array<String>;
+  streamIds: Array<string>;
 
   _valueTag: ValueTag;
 

--- a/src/PeerConnection/RTCRtpTransceiver.js
+++ b/src/PeerConnection/RTCRtpTransceiver.js
@@ -58,7 +58,7 @@ export default class RTCRtpTransceiver {
   /**
    * メディア ID
    */
-  mid: String;
+  mid: string;
 
   /**
    * センダー


### PR DESCRIPTION

- `String` と `string` が混在していたので統一しました。
   - [eslint-plugin-flowtype のこちらの rule](https://github.com/gajus/eslint-plugin-flowtype#no-primitive-constructor-types) を参考にしています。