### PR TITLE
WIP: 組織の変更に伴い、リポジトリの URL を変更する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Native WebRTC Kit
 
-[![GitHub tag](https://img.shields.io/github/tag/react-native-webrtc-kit/react-native-webrtc-kit.svg)](https://github.com/shiguredo/react-native-webrtc-kit)
+[![GitHub tag](https://img.shields.io/github/tag/react-native-webrtc-kit/react-native-webrtc-kit.svg)](https://github.com/react-native-webrtc-kit/react-native-webrtc-kit)
 [![npm version](https://badge.fury.io/js/react-native-webrtc-kit.svg)](https://badge.fury.io/js/react-native-webrtc-kit)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/ReactNativeWebRTCKit.podspec
+++ b/ReactNativeWebRTCKit.podspec
@@ -7,11 +7,11 @@ Pod::Spec.new do |s|
   s.version      = package['version']
   s.summary      = package['description']
   s.description  = package['description']
-  s.homepage     = "https://github.com/shiguredo/react-native-webrtc-kit"
+  s.homepage     = "https://github.com/react-native-webrtc-kit/react-native-webrtc-kit"
   s.license      = package['license']
   s.author       = { "Shiguredo Inc." => "info@shiguredo.jp" }
   s.platform     = :ios, "10.0"
-  s.source       = { :git => "https://github.com/shiguredo/react-native-webrtc-kit.git", :tag => "develop" }
+  s.source       = { :git => "https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git", :tag => "develop" }
   s.source_files = "ios/*.{h,m}"
   s.requires_arc = true
   

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shiguredo/react-native-webrtc-kit.git"
+    "url": "git+https://github.com/react-native-webrtc-kit/react-native-webrtc-kit.git"
   },
   "bugs": {
-    "url": "https://github.com/shiguredo/react-native-webrtc-kit/issues"
+    "url": "https://github.com/react-native-webrtc-kit/react-native-webrtc-kit/issues"
   },
-  "homepage": "https://github.com/shiguredo/react-native-webrtc-kit#readme"
+  "homepage": "https://github.com/react-native-webrtc-kit/react-native-webrtc-kit#readme"
 }


### PR DESCRIPTION
## 変更内容

GitHub の組織の変更に伴い、リポジトリの URL を変更しました
以下のコマンドを利用しています

```
grep -l "shiguredo/react-native-webrtc-kit" | xargs -I {} sed -i "" "s:shiguredo/react-native-webrtc-kit:react-native-webrtc-kit/react-native-webrtc-kit:g" {}
```