### PR TITLE
ObjC のコードで if に braces をつけるように統一し、いくつかの warning  を解消する

### DIFF
--- a/ios/RCTConvert+WebRTC.m
+++ b/ios/RCTConvert+WebRTC.m
@@ -97,20 +97,23 @@ NS_ASSUME_NONNULL_BEGIN
         NSMutableArray<RTCIceServer *> *iceServers = [NSMutableArray new];
         for (id server in iceServersJson) {
             RTCIceServer *convert = [RCTConvert RTCIceServer: server];
-            if (convert == nil)
+            if (convert == nil) {
                 NonNullError(@"each RTCConfiguration.iceServers");
-            else
+            } else {
                 [iceServers addObject: convert];
+            }
         }
         config.iceServers = iceServers;
     }
     
     NSString *policy = Nullable(json[@"iceTransportPolicy"]);
     if (policy) {
-        if ([policy isEqualToString: @"relay"])
+        if ([policy isEqualToString: @"relay"]) {
             config.iceTransportPolicy = RTCIceTransportPolicyRelay;
-        else if ([policy isEqualToString: @"all"])
+        }
+        else if ([policy isEqualToString: @"all"]) {
             config.iceTransportPolicy = RTCIceTransportPolicyAll;
+        }
         else {
             InvalidValueError(@"RTCConfiguration.iceTransportPolicy", policy);
             return nil;
@@ -119,10 +122,12 @@ NS_ASSUME_NONNULL_BEGIN
     
     NSString *semantics = Nullable(json[@"sdpSemantics"]);
     if (semantics) {
-        if ([semantics isEqualToString: @"planb"])
+        if ([semantics isEqualToString: @"planb"]) {
             config.sdpSemantics = RTCSdpSemanticsPlanB;
-        else if ([semantics isEqualToString: @"unified"])
+        }
+        else if ([semantics isEqualToString: @"unified"]) {
             config.sdpSemantics = RTCSdpSemanticsUnifiedPlan;
+        }
         else {
             InvalidValueError(@"RTCConfiguration.sdpSemantics", semantics);
             return nil;
@@ -165,25 +170,26 @@ NS_ASSUME_NONNULL_BEGIN
         }
         
         NSNumber *width = videoConsts[@"width"];
-        if (width)
+        if (width) {
             consts.video.width = [width intValue];
-        
+        }
         NSNumber *height = videoConsts[@"height"];
         if (height) {
             consts.video.height = [height intValue];
         }
         
         NSNumber *frameRate = videoConsts[@"frameRate"];
-        if (frameRate)
+        if (frameRate) {
             consts.video.frameRate = [frameRate intValue];
-        
+        }
         NSNumber *aspectRatio = videoConsts[@"aspectRatio"];
-        if (aspectRatio)
+        if (aspectRatio) {
             consts.video.aspectRatio = (CGFloat)[aspectRatio doubleValue];
-        
+        }
         NSString *sourceId = videoConsts[@"sourceId"];
-        if (sourceId)
+        if (sourceId) {
             consts.video.sourceId = sourceId;
+        }
     }
     
     id audioConsts = Nullable(json[@"audio"]);

--- a/ios/RCTConvert+WebRTC.m
+++ b/ios/RCTConvert+WebRTC.m
@@ -26,7 +26,8 @@ do { \
     if (IsNull(json)) { \
         RCTLogError(@"%@: JSON value must not be null", propName); \
         return nil; \
-    } else if (![json isKindOfClass: NSClassFromString(@"" #className)]) { \
+    }
+    else if (![json isKindOfClass: NSClassFromString(@"" #className)]) { \
         RCTLogError(@"%@: JSON value '%@' of type %@ cannot be converted to %@", \
             propName, json, [json classForCoder], @"" #className); \
         return nil; \
@@ -99,7 +100,8 @@ NS_ASSUME_NONNULL_BEGIN
             RTCIceServer *convert = [RCTConvert RTCIceServer: server];
             if (convert == nil) {
                 NonNullError(@"each RTCConfiguration.iceServers");
-            } else {
+            }
+            else {
                 [iceServers addObject: convert];
             }
         }
@@ -237,7 +239,8 @@ NS_ASSUME_NONNULL_BEGIN
     if (isBinary) {
         // バイナリデータの場合 Base64 Encoded した NS Data  に変換
         data = [[NSData alloc] initWithBase64EncodedString:json[@"data"] options:0];
-    } else {
+    }
+    else {
         // それ以外の場合は UTF8 String Encoding で NSData に変換
         data = [json[@"data"] dataUsingEncoding:NSUTF8StringEncoding];
     }

--- a/ios/WebRTCModule+RTCDataChannel.m
+++ b/ios/WebRTCModule+RTCDataChannel.m
@@ -92,7 +92,8 @@ RCT_EXPORT_METHOD(dataChannelClose:(nonnull NSString *) valueTag)
     if (buffer.isBinary) {
       // バイナリデータの場合は base64 で string に戻す
       data = [buffer.data base64EncodedStringWithOptions:0];
-    } else {
+    }
+    else {
        // バイナリデータでない場合、UTF-8 エンコーディングで string に戻す
       data = [[NSString alloc] initWithData:buffer.data
                                    encoding:NSUTF8StringEncoding];

--- a/ios/WebRTCModule+RTCDataChannel.m
+++ b/ios/WebRTCModule+RTCDataChannel.m
@@ -80,7 +80,7 @@ RCT_EXPORT_METHOD(dataChannelClose:(nonnull NSString *) valueTag)
                                                             @"valueTag": channel.valueTag,
                                                             @"readyState": [WebRTCUtils stringForDataChannelState:channel.readyState]}];
     // data channel が閉じられた場合はモジュールの管理から該当の dataChannel を外す
-    if(channel.readyState == RTCDataChannelStateClosed) {
+    if (channel.readyState == RTCDataChannelStateClosed) {
         [self removeDataChannelForKey:channel.valueTag];
     }
 }

--- a/ios/WebRTCModule+RTCMediaStream.m
+++ b/ios/WebRTCModule+RTCMediaStream.m
@@ -98,8 +98,9 @@ RCT_EXPORT_METHOD(trackSetEnabled:(nonnull NSNumber *)isEnabled
                   valueTag:(nonnull NSString *)valueTag)
 {
     RTCMediaStreamTrack *track = [self trackForKey: valueTag];
-    if (track)
+    if (track) {
         track.isEnabled = [isEnabled boolValue];
+    }
 }
 
 // MARK: -trackSetAspectRatio:trackId:valueTag:

--- a/ios/WebRTCModule+RTCMediaStream.m
+++ b/ios/WebRTCModule+RTCMediaStream.m
@@ -23,12 +23,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable RTCMediaStreamTrack *)trackForTrackId:(NSString *)trackId
 {
     for (RTCMediaStreamTrack *track in self.videoTracks) {
-        if ([track.trackId isEqualToString: trackId])
+        if ([track.trackId isEqualToString: trackId]) {
             return track;
+        }
     }
     for (RTCMediaStreamTrack *track in self.audioTracks) {
-        if ([track.trackId isEqualToString: trackId])
+        if ([track.trackId isEqualToString: trackId]) {
             return track;
+        }
     }
     return nil;
 }

--- a/ios/WebRTCModule+RTCPeerConnection.h
+++ b/ios/WebRTCModule+RTCPeerConnection.h
@@ -27,9 +27,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)json;
 
-+ (NSString *)directionDescription:(RTCRtpTransceiverDirection)direction;
-+ (RTCRtpTransceiverDirection)directionFromString:(NSString *)string;
-
 @end
 
 @interface RTCRtpTransceiver (ReactNativeWebRTCKit)

--- a/ios/WebRTCModule+RTCPeerConnection.m
+++ b/ios/WebRTCModule+RTCPeerConnection.m
@@ -287,7 +287,8 @@ RCT_EXPORT_METHOD(transceiverCurrentDirection:(nonnull NSString *)valueTag
     id ret;
     if ([transceiver currentDirection: &dir]) {
         ret = [RTCRtpTransceiver directionDescription: dir];
-    } else {
+    }
+    else {
         ret = [NSNull null];
     }
     resolve(ret);
@@ -466,7 +467,8 @@ RCT_EXPORT_METHOD(peerConnectionRemoveTrack:(nonnull NSString *)senderValueTag
     [self removeSenderForKey: senderValueTag];
     if ([peerConnection removeTrack: sender]) {
         resolve(nil);
-    } else {
+    }
+    else {
         reject(@"RemoveTrackFailed", @"cannot remove track", nil);
     }
 }
@@ -487,7 +489,8 @@ RCT_EXPORT_METHOD(peerConnectionCreateOffer:(nonnull NSString *)valueTag
                       completionHandler:^(RTCSessionDescription *sdp, NSError *error) {
                           if (error) {
                               reject(@"CreateOfferFailed", error.userInfo[@"error"], error);
-                          } else {
+                          }
+                          else {
                               NSString *type = [RTCSessionDescription stringForType:sdp.type];
                               resolve(@{@"sdp": sdp.sdp, @"type": type});
                           }
@@ -509,7 +512,8 @@ RCT_EXPORT_METHOD(peerConnectionCreateAnswer:(nonnull NSString *)valueTag
                        completionHandler:^(RTCSessionDescription *sdp, NSError *error) {
                            if (error) {
                                reject(@"CreateAnswerFailed", error.userInfo[@"error"], error);
-                           } else {
+                            }
+                            else {
                                NSString *type = [RTCSessionDescription stringForType:sdp.type];
                                resolve(@{@"sdp": sdp.sdp, @"type": type});
                            }
@@ -531,7 +535,8 @@ RCT_EXPORT_METHOD(peerConnectionSetLocalDescription:(nonnull RTCSessionDescripti
                       completionHandler: ^(NSError *error) {
                           if (error) {
                               reject(@"SetLocalDescriptionFailed", error.localizedDescription, error);
-                          } else {
+                          }
+                          else {
                               resolve(nil);
                           }
                       }];

--- a/ios/WebRTCModule+RTCPeerConnection.m
+++ b/ios/WebRTCModule+RTCPeerConnection.m
@@ -33,12 +33,15 @@ static const char *streamIdsKey = "streamIds";
     for (RTCRtpEncodingParameters *enc in self.encodings) {
         NSMutableDictionary *json = [[NSMutableDictionary alloc] init];
         json[@"active"] = [[NSNumber alloc] initWithBool: enc.isActive];
-        if (enc.maxBitrateBps)
+        if (enc.maxBitrateBps) {
             json[@"maxBitrate"] = enc.maxBitrateBps;
-        if (enc.minBitrateBps)
+        }
+        if (enc.minBitrateBps) {
             json[@"minBitrate"] = enc.minBitrateBps;
-        if (enc.ssrc)
+        }
+        if (enc.ssrc) {
             json[@"ssrc"] = enc.ssrc;
+        }
         [encodings addObject: json];
     }
     
@@ -49,10 +52,12 @@ static const char *streamIdsKey = "streamIds";
         json[@"mimeType"] = [NSString stringWithFormat: @"%@/%@",
                              codec.kind, codec.name];
         json[@"parameters"] = codec.parameters;
-        if (codec.clockRate)
+        if (codec.clockRate) {
             json[@"clockRate"] = codec.clockRate;
-        if (codec.numChannels)
+        }
+        if (codec.numChannels) {
             json[@"channels"] = codec.numChannels;
+        }
         [codecs addObject: json];
     }
     
@@ -106,10 +111,12 @@ static const char *streamIdsKey = "streamIds";
     json[@"id"] = self.senderId;
     json[@"parameters"] = [self.parameters json];
     json[@"streamIds"] = self.streamIds;
-    if (self.valueTag)
+    if (self.valueTag) {
         json[@"valueTag"] = self.valueTag;
-    if (track)
+    }
+    if (track) {
         json[@"track"] = [track json];
+    }
     return json;
 }
 
@@ -193,8 +200,9 @@ static const char *streamIdsKey = "streamIds";
        @"sender": [self.sender json],
        @"receiver": [self.receiver json],
        @"stopped": [NSNumber numberWithBool: self.isStopped]}];
-    if (self.valueTag)
+    if (self.valueTag) {
         json[@"valueTag"] = self.valueTag;
+    }
     return json;
 }
 
@@ -209,21 +217,23 @@ static const char *streamIdsKey = "streamIds";
             return @"recvonly";
         case RTCRtpTransceiverDirectionInactive:
             return @"inactive";
-        case RTCRtpTransceiverDirectionStopped:
-            return @"stopped";
     }
 }
 
 + (RTCRtpTransceiverDirection)directionFromString:(NSString *)string
 {
-    if ([string isEqualToString: @"sendrecv"])
+    if ([string isEqualToString: @"sendrecv"]) {
         return RTCRtpTransceiverDirectionSendRecv;
-    else if ([string isEqualToString: @"sendonly"])
+    }
+    else if ([string isEqualToString: @"sendonly"]) {
         return RTCRtpTransceiverDirectionSendOnly;
-    else if ([string isEqualToString: @"recvonly"])
+    }
+    else if ([string isEqualToString: @"recvonly"]) {
         return RTCRtpTransceiverDirectionRecvOnly;
-    else if ([string isEqualToString: @"inactive"])
+    }
+    else if ([string isEqualToString: @"inactive"]) {
         return RTCRtpTransceiverDirectionInactive;
+    }
     else {
         NSAssert(NO, @"invalid direction %@", string);
         return RTCRtpTransceiverDirectionSendRecv;
@@ -313,8 +323,9 @@ static void *peerConnectionValueTagKey = "peerConnectionValueTag";
 
 - (void)closeAndFinish
 {
-    if (self.connectionState != RTCPeerConnectionStateConnected)
+    if (self.connectionState != RTCPeerConnectionStateConnected) {
         return;
+    }
     [self close];
     [self finish];
 }
@@ -333,13 +344,15 @@ static void *peerConnectionValueTagKey = "peerConnectionValueTag";
 {
     for (RTCRtpSender *sender in self.senders) {
         NSLog(@"# rtpParametersForValueTag: sender %@", [sender description]);
-        if ([sender.valueTag isEqualToString: valueTag])
+        if ([sender.valueTag isEqualToString: valueTag]) {
             return sender.parameters;
+        }
     }
     for (RTCRtpReceiver *receiver in self.receivers) {
         NSLog(@"# rtpParametersForValueTag: receiver %@", [receiver description]);
-        if ([receiver.valueTag isEqualToString: valueTag])
+        if ([receiver.valueTag isEqualToString: valueTag]) {
             return receiver.parameters;
+        }
     }
     return nil;
 }
@@ -347,11 +360,13 @@ static void *peerConnectionValueTagKey = "peerConnectionValueTag";
 - (nullable RTCRtpEncodingParameters *)rtpEncodingParametersForValueTag:(nonnull NSString *)valueTag ssrc:(nullable NSNumber *)ssrc
 {
     RTCRtpParameters *params = [self rtpParametersForValueTag: valueTag];
-    if (!params)
+    if (!params) {
         return nil;
+    }
     for (RTCRtpEncodingParameters *encParams in params.encodings) {
-        if ([encParams.ssrc isEqualToNumber: ssrc])
+        if ([encParams.ssrc isEqualToNumber: ssrc]) {
             return encParams;
+        }
     }
     return nil;
 }
@@ -592,10 +607,12 @@ RCT_EXPORT_METHOD(rtpEncodingParametersSetMaxBitrate:(nonnull NSNumber *)bitrate
     [self rtpEncodingParametersForValueTag: ownerValueTag
                                       ssrc: ssrc];
     if (params && [params.ssrc isEqualToNumber: ssrc]) {
-        if ([bitrate intValue] >= 0)
+        if ([bitrate intValue] >= 0) {
             params.maxBitrateBps = bitrate;
-        else
+        }
+        else {
             params.maxBitrateBps = nil;
+        }
     }
 }
 
@@ -609,10 +626,12 @@ RCT_EXPORT_METHOD(rtpEncodingParametersSetMinBitrate:(nonnull NSNumber *)bitrate
     [self rtpEncodingParametersForValueTag: ownerValueTag
                                       ssrc: ssrc];
     if (params && [params.ssrc isEqualToNumber: ssrc]) {
-        if ([bitrate intValue] >= 0)
+        if ([bitrate intValue] >= 0) {
             params.minBitrateBps = bitrate;
-        else
+        }
+        else {
             params.minBitrateBps = nil;
+        }
     }
 }
 
@@ -649,8 +668,9 @@ RCT_EXPORT_METHOD(peerConnectionCreateDataChannel: (NSString *)label
 - (void)peerConnection:(RTCPeerConnection *)peerConnection
 didChangeConnectionState:(RTCPeerConnectionState)newState
 {
-    if (newState == RTCPeerConnectionStateClosed)
+    if (newState == RTCPeerConnectionStateClosed) {
         [peerConnection finish];
+    }
     
     [self.bridge.eventDispatcher sendDeviceEventWithName:@"peerConnectionConnectionStateChanged"
                                                     body:@{@"valueTag": peerConnection.valueTag,

--- a/ios/WebRTCModule+RTCPeerConnection.m
+++ b/ios/WebRTCModule+RTCPeerConnection.m
@@ -217,6 +217,8 @@ static const char *streamIdsKey = "streamIds";
             return @"recvonly";
         case RTCRtpTransceiverDirectionInactive:
             return @"inactive";
+        case RTCRtpTransceiverDirectionStopped:
+            return @"stopped";
     }
 }
 

--- a/ios/WebRTCModule+getUserMedia.h
+++ b/ios/WebRTCModule+getUserMedia.h
@@ -41,9 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface WebRTCModule (getUserMedia)
-
-- (void)reloadGetUserMedia;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/WebRTCModule+getUserMedia.m
+++ b/ios/WebRTCModule+getUserMedia.m
@@ -16,8 +16,9 @@ static WebRTCCameraVideoCapturer *sharedCameraVideoCapturer = nil;
 
 + (WebRTCCameraVideoCapturer *)shared
 {
-    if (!sharedCameraVideoCapturer)
+    if (!sharedCameraVideoCapturer) {
         sharedCameraVideoCapturer = [[WebRTCCameraVideoCapturer alloc] init];
+    }
     return sharedCameraVideoCapturer;
 }
 
@@ -42,8 +43,9 @@ static WebRTCCameraVideoCapturer *sharedCameraVideoCapturer = nil;
 + (nullable AVCaptureDevice *)captureDeviceForPosition:(AVCaptureDevicePosition)position
 {
     for (AVCaptureDevice *device in [WebRTCCameraVideoCapturer captureDevices]) {
-        if (device.position == position)
+        if (device.position == position) {
             return device;
+        }
     }
     return nil;
 }
@@ -71,10 +73,12 @@ static WebRTCCameraVideoCapturer *sharedCameraVideoCapturer = nil;
 {
     int maxFrameRate = 0;
     for (AVFrameRateRange *range in [format videoSupportedFrameRateRanges]) {
-        if (maxFrameRate < range.maxFrameRate)
+        if (maxFrameRate < range.maxFrameRate) {
             maxFrameRate = range.maxFrameRate;
-        if (range.minFrameRate <= frameRate && frameRate <= range.maxFrameRate)
+        }
+        if (range.minFrameRate <= frameRate && frameRate <= range.maxFrameRate) {
             return frameRate;
+        }
     }
     return maxFrameRate;
 }
@@ -110,9 +114,9 @@ static WebRTCCameraVideoCapturer *sharedCameraVideoCapturer = nil;
                      frameRate:(int)frameRate
              completionHandler:(nullable void (^)(NSError *))completionHandler;
 {
-    if (_isRunning)
+    if (_isRunning) {
         return;
-    
+    }
     _isRunning = YES;
     frameRate = [WebRTCCameraVideoCapturer suitableFrameRateForFormat: format
                                                             frameRate: frameRate];
@@ -131,9 +135,10 @@ static WebRTCCameraVideoCapturer *sharedCameraVideoCapturer = nil;
 {
     if (_isRunning) {
         [_nativeCapturer stopCaptureWithCompletionHandler: ^() {
-            if (completionHandler)
+            if (completionHandler) {
                 completionHandler();
-            _isRunning = NO;
+            }
+            self->_isRunning = NO;
         }];
     }
 }
@@ -142,9 +147,9 @@ static WebRTCCameraVideoCapturer *sharedCameraVideoCapturer = nil;
 
 - (void)capturer:(RTCVideoCapturer *)capturer didCaptureVideoFrame:(RTCVideoFrame *)frame
 {
-    if (!_isRunning)
+    if (!_isRunning) {
         return;
-
+    }
     // すべてのローカルストリームに対して映像フレームを渡し、
     // タグに対するストリームが存在しない場合はタグを消す。
     NSMutableArray *tagsToRemove = nil;
@@ -156,8 +161,9 @@ static WebRTCCameraVideoCapturer *sharedCameraVideoCapturer = nil;
             RTCVideoTrack *video = (RTCVideoTrack *)track;
             [video.source capturer: capturer didCaptureVideoFrame: frame];
         } else {
-            if (!tagsToRemove)
+            if (!tagsToRemove) {
                 tagsToRemove = [[NSMutableArray alloc] init];
+            }
             [tagsToRemove addObject: valueTag];
         }
     }
@@ -190,8 +196,9 @@ static WebRTCCameraVideoCapturer *sharedCameraVideoCapturer = nil;
     dispatch_sync(self.lock, ^{
         NSMutableArray *new = [[NSMutableArray alloc] init];
         for (NSString *old in _trackValueTags) {
-            if (![old isEqualToString: valueTag])
+            if (![old isEqualToString: valueTag]) {
                 [new addObject: valueTag];
+            }
         }
         _trackValueTags = new;
     });
@@ -211,12 +218,12 @@ RCT_EXPORT_METHOD(getUserMedia:(WebRTCMediaStreamConstraints *)constraints
     // libwebrtc でカメラを起動すると自動的にマイクも起動される
     // そのため、音声のみ必要な場合でもカメラを起動する必要がある
     if (constraints.video) {
-        AVCaptureDevicePosition *position;
-        if ([constraints.video.facingMode isEqualToString: WebRTCFacingModeUser])
+        AVCaptureDevicePosition position;
+        if ([constraints.video.facingMode isEqualToString: WebRTCFacingModeUser]) {
             position = AVCaptureDevicePositionFront;
-        else
+        } else {
             position = AVCaptureDevicePositionBack;
-
+        }
         AVCaptureDevice *device = [WebRTCCameraVideoCapturer captureDeviceForPosition: position];
         if (!device) {
             reject(@"NotFoundError", @"video capturer is not found", nil);

--- a/ios/WebRTCModule+getUserMedia.m
+++ b/ios/WebRTCModule+getUserMedia.m
@@ -160,7 +160,8 @@ static WebRTCCameraVideoCapturer *sharedCameraVideoCapturer = nil;
             track.readyState == RTCMediaStreamTrackStateLive) {
             RTCVideoTrack *video = (RTCVideoTrack *)track;
             [video.source capturer: capturer didCaptureVideoFrame: frame];
-        } else {
+        }
+        else {
             if (!tagsToRemove) {
                 tagsToRemove = [[NSMutableArray alloc] init];
             }
@@ -221,7 +222,8 @@ RCT_EXPORT_METHOD(getUserMedia:(WebRTCMediaStreamConstraints *)constraints
         AVCaptureDevicePosition position;
         if ([constraints.video.facingMode isEqualToString: WebRTCFacingModeUser]) {
             position = AVCaptureDevicePositionFront;
-        } else {
+        }
+        else {
             position = AVCaptureDevicePositionBack;
         }
         AVCaptureDevice *device = [WebRTCCameraVideoCapturer captureDeviceForPosition: position];
@@ -245,7 +247,8 @@ RCT_EXPORT_METHOD(getUserMedia:(WebRTCMediaStreamConstraints *)constraints
         [WebRTCCamera startCaptureWithDevice: device
                                       format: format
                                    frameRate: frameRate];
-    } else {
+    }
+    else {
         // 映像が不要の場合でも、マイクを起動するためにカメラを起動しておく
         // その場合は後々ストリームから映像トラックを外す
         [WebRTCCamera startCaptureWithAllDevices];

--- a/ios/WebRTCModule.m
+++ b/ios/WebRTCModule.m
@@ -352,11 +352,13 @@ RCT_EXPORT_METHOD(getAndResetMetrics:(nonnull RCTPromiseResolveBlock)resolve
 // MARK: -getAudioPort:resolver:rejecter:
 RCT_REMAP_METHOD(getAudioPort, resolver: (RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject){
-    if(self.portOverride == AVAudioSessionPortOverrideSpeaker){
+    if (self.portOverride == AVAudioSessionPortOverrideSpeaker) {
         resolve(@"speaker");
-    }else if(self.portOverride == AVAudioSessionPortOverrideNone){
+    }
+    else if (self.portOverride == AVAudioSessionPortOverrideNone) {
         resolve(@"none");
-    }else{
+    }
+    else {
         resolve(@"unknown");
     }
 }
@@ -377,7 +379,8 @@ RCT_EXPORT_METHOD(setAudioPort:(NSString *)port
                                      if ([session overrideOutputAudioPort:override error:&error]) {
                                          self.portOverride = override;
                                          resolve(nil);
-                                     } else {
+                                     }
+                                     else {
                                          RTCLogError(@"Error overriding output port: %@",
                                                      error.localizedDescription);
                                      }

--- a/ios/WebRTCUtils.m
+++ b/ios/WebRTCUtils.m
@@ -80,7 +80,8 @@
         NSString *value;
         if ([obj isKindOfClass:[NSNumber class]]) {
             value = [obj boolValue] ? @"true" : @"false";
-        } else {
+        }
+        else {
             value = [obj description];
         }
         result[[key description]] = value;

--- a/ios/WebRTCVideoView.m
+++ b/ios/WebRTCVideoView.m
@@ -57,7 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.videoTrack addRenderer:self];
                 self.isRendererAdded = YES;
             }
-        } else {
+        }
+        else {
             // ウィンドウから外れたらレンダラーも外す。
             // トラックにレンダラーが追加されたままだと、
             // バックグラウンドで描画しようとして UIView の警告が出る。
@@ -74,15 +75,18 @@ NS_ASSUME_NONNULL_BEGIN
     CGRect newFrame;
     if (width <= 0 || height <= 0) {
         newFrame = CGRectZero;
-    } else if (self.videoTrack.aspectRatio > 0) {
+    }
+    else if (self.videoTrack.aspectRatio > 0) {
         CGFloat ratio = self.videoTrack.aspectRatio;
         newFrame = self.bounds;
         newFrame.size.width = newFrame.size.height * ratio;
         newFrame.origin.x += (self.bounds.size.width - newFrame.size.width) / 2.0;
-    } else if (self.contentMode == UIViewContentModeScaleToFill) {
+    }
+    else if (self.contentMode == UIViewContentModeScaleToFill) {
         // objectFit: fill
         newFrame = self.bounds;
-    } else if (self.contentMode == UIViewContentModeScaleAspectFill) {
+    }
+    else if (self.contentMode == UIViewContentModeScaleAspectFill) {
         // objectFit: cover
         newFrame = self.bounds;
         if (newFrame.size.width != width || newFrame.size.height != height) {
@@ -94,7 +98,8 @@ NS_ASSUME_NONNULL_BEGIN
             newFrame.size.width = width;
             newFrame.size.height = height;
         }
-    } else {
+    }
+    else {
         // objectFit: contain
         newFrame = AVMakeRectWithAspectRatioInsideRect(CGSizeMake(width, height), self.bounds);
     }

--- a/ios/WebRTCVideoViewManager.m
+++ b/ios/WebRTCVideoViewManager.m
@@ -22,11 +22,14 @@ RCT_CUSTOM_VIEW_PROPERTY(objectFit, NSString *, WebRTCVideoView) {
     UIViewContentMode contentMode;
     if ([s isEqualToString:@"fill"]) {
         contentMode = UIViewContentModeScaleToFill;
-    } else if ([s isEqualToString:@"cover"]) {
+    }
+    else if ([s isEqualToString:@"cover"]) {
         contentMode = UIViewContentModeScaleAspectFit;
-    } else if ([s isEqualToString:@"contain"]) {
+    }
+    else if ([s isEqualToString:@"contain"]) {
         contentMode = UIViewContentModeScaleAspectFill;
-    } else {
+    }
+    else {
         contentMode = UIViewContentModeScaleAspectFill;
     }
     view.contentMode = contentMode;


### PR DESCRIPTION
- if braces の規則については [NYTimes のコード規約](https://github.com/NYTimes/objective-c-style-guide#conditionals) に従いました
- implement されていない interface の function を削除しました