### PR TITLE
Feature/m84

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,16 @@
 
 ## develop
 
+- [CHANGES] WebRTC M84 に対応する
+    - @enm10k
 - [UPDATE] 利用していない `mergedMediaConstraints` 関数を削除する
     - @kdxu
 - [UPDATE] ObjC のコードの if に braces をつけるように統一し、いくつかの warning  を解消する
     - @kdxu
 - [UPDATE] コンストラクタで String と annotation しているものを string に統一する
     - @kdxu
+- [ADD] iOS でマイクの使用/不使用を指定できる API を追加する
+    - @enm10k
 
 ## 2020.4.0
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # React Native WebRTC Kit
 
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-m84.4147.11-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/4147)
 [![GitHub tag](https://img.shields.io/github/tag/react-native-webrtc-kit/react-native-webrtc-kit.svg)](https://github.com/react-native-webrtc-kit/react-native-webrtc-kit)
 [![npm version](https://badge.fury.io/js/react-native-webrtc-kit.svg)](https://badge.fury.io/js/react-native-webrtc-kit)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -7,9 +8,9 @@
 React Native WebRTC Kit は、 React Native アプリケーションから WebRTC ネイティブライブラリを使うためのライブラリです。  
 本ライブラリを使うと、マルチプラットフォームに対応する WebRTC ネイティブアプリケーションを React Native で開発できます。  
 
-## 対応 libwebrtc バージョン
+## 利用 libwebrtc バージョン
 
-本ライブラリは WebRTC M84 に対応しています。
+本ライブラリは WebRTC M84 を利用しています。
 
 ## Web API (ブラウザ) との互換性について
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ React Native WebRTC Kit は、 React Native アプリケーションから WebRT
 
 ## 対応 libwebrtc バージョン
 
-本ライブラリは WebRTC M83 に対応しています。
+本ライブラリは WebRTC M84 に対応しています。
 
 ## Web API (ブラウザ) との互換性について
 

--- a/ReactNativeWebRTCKit.podspec
+++ b/ReactNativeWebRTCKit.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   
   s.dependency "React"
-  s.dependency "WebRTC", "~> 83.4103.12.0" # source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
+  s.dependency "WebRTC", "~> 84.4147.11.0" # source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "com.github.shiguredo:shiguredo-webrtc-android:83.4103.12.2"
+    api "com.github.shiguredo:shiguredo-webrtc-android:84.4147.11.0"
     implementation "androidx.annotation:annotation:1.1.0"
 }
   

--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@ export type { RTCSdpType } from './src/PeerConnection/RTCSessionDescription';
 export type { RTCUserMedia } from './src/MediaDevice/getUserMedia';
 export type { RTCAudioPort } from './src/MediaDevice/RTCAudioPort';
 
-// ネイティブモジュールに JS レイヤーのロードを知らせる。
-// デバッグモードでのリロード時に古い接続の終了処理を行う。
-// ネイティブ側で終了処理を行わないと、リロード前の接続が残ってしまう。
 import { NativeModules } from 'react-native';
 
 const { WebRTCModule } = NativeModules;
+// ネイティブモジュールに JS レイヤーのロードを知らせる。
+// デバッグモードでのリロード時に古い接続の終了処理を行う。
+// ネイティブ側で終了処理を行わないと、リロード前の接続が残ってしまう。
 WebRTCModule.finishLoading();

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 // @flow
 
-import WebRTC from './src/WebRTC';
-
+export { default as WebRTC } from './src/WebRTC';
 export { RTCEvent } from './src/Event/RTCEvents';
 export { RTCMediaStreamTrackEvent } from './src/Event/RTCEvents';
 export { RTCIceCandidateEvent } from './src/Event/RTCEvents';
@@ -41,4 +40,7 @@ export type { RTCAudioPort } from './src/MediaDevice/RTCAudioPort';
 // ネイティブモジュールに JS レイヤーのロードを知らせる。
 // デバッグモードでのリロード時に古い接続の終了処理を行う。
 // ネイティブ側で終了処理を行わないと、リロード前の接続が残ってしまう。
-WebRTC.finishLoading();
+import { NativeModules } from 'react-native';
+
+const { WebRTCModule } = NativeModules;
+WebRTCModule.finishLoading();

--- a/ios/WebRTCModule+RTCPeerConnection.m
+++ b/ios/WebRTCModule+RTCPeerConnection.m
@@ -401,6 +401,24 @@ RCT_EXPORT_METHOD(peerConnectionInit:(nonnull RTCConfiguration *)configuration
                                                     constraints: mediaConsts
                                                        delegate: self];
     peerConnection.valueTag = valueTag;
+    
+    
+    BOOL microphoneEnabled = [[WebRTCModule shared] microphoneEnabled];
+    BOOL microphoneInitialized = [[WebRTCModule shared] microphoneInitialized];
+
+    if (microphoneEnabled && !microphoneInitialized) {
+        RTCAudioSessionConfiguration.webRTCConfiguration.category = AVAudioSessionCategoryPlayAndRecord;
+        RTCAudioSession *session = [RTCAudioSession sharedInstance];
+        [session initializeInput:^(NSError * _Nullable error) {
+            if (error != NULL) {
+                NSLog(@"failed to initialize audio input: %@", error);
+                return;
+            }
+            [WebRTCModule shared].microphoneInitialized = YES;
+            NSLog(@"audio input is initialized");
+        }];
+    }
+    
     [self addPeerConnection: peerConnection forKey: valueTag];
 }
 

--- a/ios/WebRTCModule+RTCPeerConnection.m
+++ b/ios/WebRTCModule+RTCPeerConnection.m
@@ -402,7 +402,6 @@ RCT_EXPORT_METHOD(peerConnectionInit:(nonnull RTCConfiguration *)configuration
                                                        delegate: self];
     peerConnection.valueTag = valueTag;
     
-    
     BOOL microphoneEnabled = [[WebRTCModule shared] microphoneEnabled];
     BOOL microphoneInitialized = [[WebRTCModule shared] microphoneInitialized];
 

--- a/ios/WebRTCModule+RTCPeerConnection.m
+++ b/ios/WebRTCModule+RTCPeerConnection.m
@@ -401,23 +401,6 @@ RCT_EXPORT_METHOD(peerConnectionInit:(nonnull RTCConfiguration *)configuration
                                                     constraints: mediaConsts
                                                        delegate: self];
     peerConnection.valueTag = valueTag;
-    
-    BOOL microphoneEnabled = [[WebRTCModule shared] microphoneEnabled];
-    BOOL microphoneInitialized = [[WebRTCModule shared] microphoneInitialized];
-
-    if (microphoneEnabled && !microphoneInitialized) {
-        RTCAudioSessionConfiguration.webRTCConfiguration.category = AVAudioSessionCategoryPlayAndRecord;
-        RTCAudioSession *session = [RTCAudioSession sharedInstance];
-        [session initializeInput:^(NSError * _Nullable error) {
-            if (error != NULL) {
-                NSLog(@"failed to initialize audio input: %@", error);
-                return;
-            }
-            [WebRTCModule shared].microphoneInitialized = YES;
-            NSLog(@"audio input is initialized");
-        }];
-    }
-    
     [self addPeerConnection: peerConnection forKey: valueTag];
 }
 
@@ -570,6 +553,22 @@ RCT_EXPORT_METHOD(peerConnectionSetRemoteDescription:(nonnull RTCSessionDescript
         return;
     }
     
+    // マイクの初期化処理
+    BOOL microphoneEnabled = [[WebRTCModule shared] microphoneEnabled];
+    BOOL microphoneInitialized = [[WebRTCModule shared] microphoneInitialized];
+    if (microphoneEnabled && !microphoneInitialized) {
+        RTCAudioSessionConfiguration.webRTCConfiguration.category = AVAudioSessionCategoryPlayAndRecord;
+        RTCAudioSession *session = [RTCAudioSession sharedInstance];
+        [session initializeInput:^(NSError * _Nullable error) {
+            if (error != NULL) {
+                NSLog(@"failed to initialize audio input: %@", error);
+                return;
+            }
+            [WebRTCModule shared].microphoneInitialized = YES;
+            NSLog(@"audio input is initialized");
+        }];
+    }
+
     [peerConnection setRemoteDescription:sdp
                        completionHandler: ^(NSError *error) {
                            if (error) {

--- a/ios/WebRTCModule.h
+++ b/ios/WebRTCModule.h
@@ -38,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 // @property (nonatomic, readonly) NSArray <RTCDataChannel *> *dataChannels;
 
 @property(nonatomic, assign) AVAudioSessionPortOverride portOverride;
+@property(nonatomic) BOOL microphoneEnabled;
+@property(nonatomic) BOOL microphoneInitialized;
 
 + (WebRTCModule *)shared;
 

--- a/ios/WebRTCModule.m
+++ b/ios/WebRTCModule.m
@@ -64,6 +64,8 @@ static WebRTCModule *sharedModule;
         self.transceiverDict = [NSMutableDictionary dictionary];
         self.dataChannelDict = [NSMutableDictionary dictionary];
         self.portOverride = AVAudioSessionPortOverrideNone;
+        self.microphoneEnabled = YES;
+        self.microphoneInitialized = NO;
         dispatch_queue_attr_t attributes =
         dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL,
                                                 QOS_CLASS_USER_INITIATED, -1);
@@ -388,6 +390,13 @@ RCT_EXPORT_METHOD(setAudioPort:(NSString *)port
                                  }];
 }
 
+RCT_REMAP_METHOD(setMicrophoneEnabled, setMicrophoneEnabledWithResolver:(BOOL)newValue
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+    self.microphoneEnabled = newValue;
+    resolve([NSNull null]);
+}
 
 @end
 

--- a/src/WebRTC.js
+++ b/src/WebRTC.js
@@ -13,11 +13,9 @@ const { WebRTCModule } = NativeModules;
  */
 export default class WebRTC {
 
-  static setMicrophoneEnabled(newValue) {
+  static async setMicrophoneEnabled(newValue) {
     if (Platform.OS === 'ios') {
-      (async () => {
-        WebRTCModule.setMicrophoneEnabled(newValue)
-      })()
+      await WebRTCModule.setMicrophoneEnabled(newValue);
     } else {
       logger.warn("# setMicrophoneEnabled() is available only on iOS");
     }

--- a/src/WebRTC.js
+++ b/src/WebRTC.js
@@ -13,7 +13,9 @@ const { WebRTCModule } = NativeModules;
  */
 export default class WebRTC {
 
-  static finishLoading() {
-    WebRTCModule.finishLoading();
+  static setMicrophoneEnabled(newValue) {
+    (async () => {
+      WebRTCModule.setMicrophoneEnabled(newValue)
+    })()
   }
 }

--- a/src/WebRTC.js
+++ b/src/WebRTC.js
@@ -14,8 +14,12 @@ const { WebRTCModule } = NativeModules;
 export default class WebRTC {
 
   static setMicrophoneEnabled(newValue) {
-    (async () => {
-      WebRTCModule.setMicrophoneEnabled(newValue)
-    })()
+    if (Platform.OS === 'ios') {
+      (async () => {
+        WebRTCModule.setMicrophoneEnabled(newValue)
+      })()
+    } else {
+      logger.warn("# setMicrophoneEnabled() is available only on iOS");
+    }
   }
 }


### PR DESCRIPTION
## 変更内容

- libwebrtc M84 への対応
- iOS でマイクの使用/不使用を指定できる API を追加する
  - 参照: https://github.com/shiguredo/shiguredo-webrtc-build/blob/develop/docs/patch_shiguredo_ios.md

## 残タスク

- レビューの依頼と並行して動作確認を行っています
- `WebRTC.setMicrophoneEnabled` は iOS でしか動作しないので、そのチェックを追加する必要があります
  - iOS 以外から呼び出された場合、 JS のレイヤーで例外を投げるコードを実装するつもりです