### PR TITLE
Feature/m86

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
 - FIX
     - バグ修正
 
+## develop
+
+- [CHANGE] WebRTC M86 に対応する
+    - @enm10k
+
 ## 2020.5.0
 
 - [CHANGES] WebRTC M84 に対応する

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Native WebRTC Kit
 
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-m84.4147.11-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/4147)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-m86.4240.1-blue.svg)](https://chromium.googlesource.com/external/webrtc/+/branch-heads/4240)
 [![GitHub tag](https://img.shields.io/github/tag/react-native-webrtc-kit/react-native-webrtc-kit.svg)](https://github.com/react-native-webrtc-kit/react-native-webrtc-kit)
 [![npm version](https://badge.fury.io/js/react-native-webrtc-kit.svg)](https://badge.fury.io/js/react-native-webrtc-kit)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -14,7 +14,7 @@ React Native WebRTC Kit は、 React Native アプリケーションから WebRT
 
 ## 利用 libwebrtc バージョン
 
-本ライブラリは WebRTC M84 を利用しています。
+本ライブラリは WebRTC M86 を利用しています。
 
 ## Web API (ブラウザ) との互換性について
 

--- a/ReactNativeWebRTCKit.podspec
+++ b/ReactNativeWebRTCKit.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   
   s.dependency "React"
-  s.dependency "WebRTC", "~> 84.4147.11.0" # source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
+  s.dependency "WebRTC", "~>  86.4240.1.2" # source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "com.github.shiguredo:shiguredo-webrtc-android:84.4147.11.0"
+    api "com.github.shiguredo:shiguredo-webrtc-android:86.4240.1.2"
     implementation "androidx.annotation:annotation:1.1.0"
 }
   

--- a/ios/WebRTCModule+RTCPeerConnection.m
+++ b/ios/WebRTCModule+RTCPeerConnection.m
@@ -269,7 +269,13 @@ RCT_EXPORT_METHOD(transceiverSetDirection:(nonnull NSString *)valueTag
     if (!transceiver) {
         reject(@"NotFoundError", @"transceiver is not found", nil);
     }
-    transceiver.direction = [RTCRtpTransceiver directionFromString: value];
+    
+    RTCRtpTransceiverDirection newDir = [RTCRtpTransceiver directionFromString: value];
+    NSError *error = nil;
+    [transceiver setDirection:newDir error:&error];
+    if (error != nil) {
+        reject(@"SetDirectionFailed", error.localizedDescription, error);
+    }
     resolve([NSNull null]);
 }
 
@@ -303,7 +309,7 @@ RCT_EXPORT_METHOD(transceiverStop:(nonnull NSString *)valueTag
     if (!transceiver) {
         reject(@"NotFoundError", @"transceiver is not found", nil);
     }
-    [transceiver stop];
+    [transceiver stopInternal];
     resolve([NSNull null]);
 }
 

--- a/test/Touchstone/android/build.gradle
+++ b/test/Touchstone/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 28
         targetSdkVersion = 28
     }


### PR DESCRIPTION
## 概要

- WebRTC M86 に対応しました
  - iOS ... third_party/webrtc/sdk/objc/api/peerconnection/RTCRtpTransceiver.mm のインターフェースに破壊的な変更があったため対応しています
    - direction プロパティに直接アクセスせずに、 setDirection を利用する
 https://source.chromium.org/chromium/chromium/src/+/master:third_party/webrtc/sdk/objc/api/peerconnection/RTCRtpTransceiver.mm;l=80?q=SetDirection&ss=chromium%2Fchromium%2Fsrc:third_party%2Fwebrtc%2Fsdk%2Fobjc%2F
    - stop が stopInternal に変更された https://source.chromium.org/chromium/chromium/src/+/master:third_party/webrtc/sdk/objc/api/peerconnection/RTCRtpTransceiver.mm?q=stopInternal&ss=chromium%2Fchromium%2Fsrc:third_party%2Fwebrtc%2Fsdk%2Fobjc%2F
  - Android ... Touchstone のビルドで以下のエラーが出たため、 build.gradle の minSdkVersion を 21 に上げています

```
$ gradlew check
...
> Task :app:javaPreCompileDebug
> Task :app:createDebugCompatibleScreenManifests
/home/runner/work/react-native-webrtc-kit/react-native-webrtc-kit/test/Touchstone/android/app/src/debug/AndroidManifest.xml Error:
	uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.github.shiguredo:shiguredo-webrtc-android:86.4240.1.2] /home/runner/.gradle/caches/transforms-2/files-2.1/aabb6829f53f8e0ff4e56fdee3c6beba/jetified-shiguredo-webrtc-android-86.4240.1.2/AndroidManifest.xml as the library might be using APIs not available in 16
> Task :app:processDebugManifest FAILED
	Suggestion: use a compatible library with a minSdk of at most 16,
		or increase this project's minSdk version to at least 21,
See http://g.co/androidstudio/manifest-merger for more information about the manifest merger.
		or use tools:overrideLibrary="org.webrtc" to force usage (may lead to runtime failures)
...
```