### PR TITLE
iOS でマイクの初期化状態を管理するフラグを PeerConnection に持たせる

### DIFF
--- a/ios/WebRTCModule+RTCPeerConnection.h
+++ b/ios/WebRTCModule+RTCPeerConnection.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RTCPeerConnection (ReactNativeWebRTCKit) <WebRTCExportable>
 
 @property (nonatomic, nullable) NSString *valueTag;
+@property (nonatomic) BOOL microphoneInitialized;
 
 /**
  * 通常の close を含む React Native 向けの終了処理を行う

--- a/ios/WebRTCModule.h
+++ b/ios/WebRTCModule.h
@@ -39,7 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, assign) AVAudioSessionPortOverride portOverride;
 @property(nonatomic) BOOL microphoneEnabled;
-@property(nonatomic) BOOL microphoneInitialized;
 
 + (WebRTCModule *)shared;
 

--- a/ios/WebRTCModule.m
+++ b/ios/WebRTCModule.m
@@ -65,7 +65,6 @@ static WebRTCModule *sharedModule;
         self.dataChannelDict = [NSMutableDictionary dictionary];
         self.portOverride = AVAudioSessionPortOverrideNone;
         self.microphoneEnabled = YES;
-        self.microphoneInitialized = NO;
         dispatch_queue_attr_t attributes =
         dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL,
                                                 QOS_CLASS_USER_INITIATED, -1);


### PR DESCRIPTION
## 変更内容

[2020.5.0](https://github.com/react-native-webrtc-kit/react-native-webrtc-kit/releases/tag/2020.5.0) で iOS にマイクの使用/不使用を指定する API を追加しましたが、マイクの初期化状態の管理に誤りがありました

修正前は WebRTCModule に microphoneInitialized というフラグを持たせていましたが、この実装では最初の PeerConnection でしか initializeInput が実行されません
修正後は PeerConnection にフラグを持たせることで、 PeerConnection ごとに initializeInput が実行されるようにします