### PR TITLE
GitHub Actions で利用しているソフトウェアのバージョンを更新する

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -10,14 +10,14 @@ on:
       - 'LICENSE'
 jobs:
   test:
-    name: Android Test on node 11.x and ubuntu-latest
+    name: Android Test on node 14.x and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 11.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 11.x
+          node-version: 14.x
       - name: yarn install
         run: |
           yarn install

--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Android Test on node 11.x and ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js 11.x
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -10,14 +10,14 @@ on:
       - 'LICENSE'
 jobs:
   test:
-    name: iOS Test on node 11.x and macos-latest
+    name: iOS Test on node 14.x and macos-latest
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 11.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 11.x
+          node-version: 14.x
       - name: yarn install
         run: |
           yarn install

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -13,7 +13,7 @@ jobs:
     name: iOS Test on node 11.x and macos-latest
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js 11.x
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
## 変更内容

- 以下のソフトウェアを更新しました
  - actions/checkout: v1 -> v2 
  - Node.js: v11 -> v14