### PR TITLE
WebRTC バイナリーを取得するリポジトリを変更する

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,14 @@ In other languages, we won't be able to deal with them. Thank you for your under
 このバイナリは弊社製品用の設定でビルドしてあるので、他のバイナリを使いたい場合は次の方法で入れ替えてください。
 
 - iOS: ビルドした `WebRTC.framework` を `ios/Pods/WebRTC/WebRTC.framework` と入れ替えます。
-    - https://github.com/shiguredo/shiguredo-webrtc-ios
+    - https://github.com/react-native-webrtc-kit/webrtc-ios
 - Android: ビルドした `libwebrtc.aar` を `android/libs/` 下に配置し、`android/build.gradle` の dependencies を以下のように編集します。
-    - https://github.com/shiguredo/shiguredo-webrtc-android
-    - トラックの削除イベント検知機能 (onRemoveTrack) を利用するには、 "com.github.shiguredo:shiguredo-webrtc-android:79.5.1" 以降の WebRTC ライブラリを利用する必要があるので、留意してください。
+    - https://github.com/react-native-webrtc-kit/webrtc-android
 
 ```
  dependencies {
      implementation 'com.facebook.react:react-native:+'
-     // api "com.github.shiguredo:shiguredo-webrtc-android:83.4103.12.2"
+     // api "com.github.react-native-webrtc-kit:webrtc-android:83.4103.12.2"
      implementation "androidx.annotation:annotation:1.1.0"
      api fileTree(dir: 'libs')
  }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "com.github.shiguredo:shiguredo-webrtc-android:86.4240.1.2"
+    api "com.github.react-native-webrtc-kit:webrtc-android:86.4240.1.2"
     implementation "androidx.annotation:annotation:1.1.0"
 }
   


### PR DESCRIPTION
## 変更内容

- 参照する WebRTC バイナリを https://github.com/react-native-webrtc-kit 以下のものに変更しました
  - iOS https://github.com/react-native-webrtc-kit/webrtc-ios
  - Android https://github.com/react-native-webrtc-kit/webrtc-android

## 関連 PR

https://github.com/react-native-webrtc-kit/react-native-webrtc-kit-samples/pull/24